### PR TITLE
fix: do not start fcitx5 daemon by im-config

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+im-config (0.57-2deepin3) unstable; urgency=medium
+
+  * Do not start fcitx5 daemon by im-config, let autostart handle it.
+
+ -- Wang Yu <wangyu@uniontech.com>  Thu, 23 Apr 2026 19:21:27 +0800
+
 im-config (0.57-2deepin2) unstable; urgency=medium
 
   * Move to main.

--- a/debian/patches/0002-do-not-start-fcitx5-daemon-by-im-config.patch
+++ b/debian/patches/0002-do-not-start-fcitx5-daemon-by-im-config.patch
@@ -1,0 +1,20 @@
+Description: Do not start fcitx5 daemon by im-config
+ fcitx5 is started via autostart desktop file, so im-config should only
+ set environment variables (Phase 1) without launching the daemon (Phase 2).
+Index: im-config/data/23_fcitx5.rc
+===================================================================
+--- im-config.orig/data/23_fcitx5.rc
++++ im-config/data/23_fcitx5.rc
+@@ -1,12 +1,6 @@
+ # start fcitx5
+ # vim: set sts=4 expandtab:
+
+-if [ "$IM_CONFIG_PHASE" = 2 ]; then
+-    # start fcitx5 daemon
+-    /usr/bin/fcitx5 -d 2> /dev/null
+-fi
+-
+-
+ if [ "$IM_CONFIG_PHASE" = 1 ]; then
+ # set variables for the plain XIM
+ XMODIFIERS=@im=fcitx

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0001-add-desktop-file-NoDisplay-true.patch
+0002-do-not-start-fcitx5-daemon-by-im-config.patch


### PR DESCRIPTION
Let fcitx5 daemon be started via autostart instead of im-config Phase 2, while im-config still sets IM environment variables (Phase 1).

让fcitx5守护进程通过autostart启动，im-config仅负责设置输入法环境变量。

Log: im-config不启动fcitx5进程，仅设环境变量
PMS: BUG-357551
Influence: fcitx5进程由桌面环境autostart启动，im-config仅设置
XMODIFIERS/GTK_IM_MODULE/QT_IM_MODULE等环境变量，避免重复启动。