### PR TITLE
fix: fix parallel build race condition between msgfmt and msgmerge

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+im-config (0.57-2deepin4) unstable; urgency=medium
+
+  * Fix parallel build race condition between msgfmt and msgmerge.
+
+ -- Wang Yu <wangyu@uniontech.com>  Wed, 23 Apr 2026 20:30:00 +0800
+
 im-config (0.57-2deepin3) unstable; urgency=medium
 
   * Do not start fcitx5 daemon by im-config, let autostart handle it.

--- a/debian/patches/0003-fix-parallel-build-race-condition.patch
+++ b/debian/patches/0003-fix-parallel-build-race-condition.patch
@@ -1,0 +1,17 @@
+Description: Fix parallel build race condition between msgfmt and msgmerge
+ When building with make -j64, msgfmt --desktop could read .po files
+ while msgmerge was still writing them, causing "syntax error" failures.
+ Add 'po' as a dependency of im-config.desktop to ensure proper ordering.
+Index: im-config/Makefile
+===================================================================
+--- im-config.orig/Makefile
++++ im-config/Makefile
+@@ -29,7 +29,7 @@ all: share/xinputrc.common im-config.desktop mo
+ share/xinputrc.common: share/xinputrc.common.in
+ 	sed -e "s/@@VERSION@@/$(VERSION)/" <$< >$@
+
+-im-config.desktop: im-config.desktop.in
++im-config.desktop: im-config.desktop.in po
+ 	msgfmt --desktop --template=$< -d po -o $@
+
+ pot: po/$(PROGRAM).pot

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 0001-add-desktop-file-NoDisplay-true.patch
 0002-do-not-start-fcitx5-daemon-by-im-config.patch
+0003-fix-parallel-build-race-condition.patch


### PR DESCRIPTION
When building with make -j64, msgfmt --desktop reads .po files while msgmerge is still writing them, causing syntax error failures. Add 'po' as dependency of im-config.desktop target to ensure ordering.

使用 make -j64 并行构建时，msgfmt --desktop 在 msgmerge 写入 .po 文件时同时读取，导致语法错误。添加 po 作为 im-config.desktop
目标的依赖以确保正确执行顺序。

Log: 修复并行构建竞态条件
Influence: 修复 CI 在 make -j64 下构建失败的问题，确保 msgmerge 完成后再执行 msgfmt --desktop。