### PR TITLE
chore: add Deepin patches for Debian 1.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+im-config (1.1-1deepin1) unstable; urgency=medium
+
+  * Rebase on Debian 1.1.
+  * Keep the Input Method settings desktop entry hidden.
+  * Do not start fcitx5 from im-config; let its autostart desktop file do so.
+  * Fix the parallel build race between catalog updates and desktop
+    translation generation.
+
+ -- Wang Yu <wangyu@uniontech.com>  Thu, 23 Jul 2026 00:00:00 +0800
+
 im-config (1.1) unstable; urgency=medium
 
   [ Andreas Tille ]

--- a/debian/patches/0001-add-desktop-file-NoDisplay-true.patch
+++ b/debian/patches/0001-add-desktop-file-NoDisplay-true.patch
@@ -1,0 +1,13 @@
+Description: Hide Input Method settings desktop entry
+ Keep the desktop entry installed for compatibility but hide it from menus.
+---
+diff --git a/im-config.desktop.in b/im-config.desktop.in
+index 829f6c1..57a0227 100644
+--- a/im-config.desktop.in
++++ b/im-config.desktop.in
+@@ -8,4 +8,5 @@ Terminal=false
+ Icon=input-keyboard
+ Categories=Settings
+ X-AppStream-Ignore=true
++NoDisplay=true
+ # https://specifications.freedesktop.org/desktop-entry/latest/

--- a/debian/patches/0002-do-not-start-fcitx5-daemon-by-im-config.patch
+++ b/debian/patches/0002-do-not-start-fcitx5-daemon-by-im-config.patch
@@ -1,0 +1,25 @@
+Description: Do not start fcitx5 daemon from im-config
+ fcitx5 is started through its autostart desktop file.  Do not configure
+ im-config to source a launcher which starts another daemon instance.
+---
+diff --git a/data/23_fcitx5.x11_env b/data/23_fcitx5.x11_env
+index 26d27ee..62b5ba1 100644
+--- a/data/23_fcitx5.x11_env
++++ b/data/23_fcitx5.x11_env
+@@ -8,5 +8,4 @@ CLUTTER_IM_MODULE=xim
+ # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1008481#40
+ SDL_IM_MODULE=fcitx
+ 
+-# daemon program to launch
+-IM_CONFIG_LAUNCH="/usr/share/im-config/data/23_fcitx5.x11_launch"
++# fcitx5 is launched by its autostart desktop file.
+diff --git a/data/23_fcitx5.x11_launch b/data/23_fcitx5.x11_launch
+deleted file mode 100644
+index 8491fd9..0000000
+--- a/data/23_fcitx5.x11_launch
++++ /dev/null
+@@ -1,4 +0,0 @@
+-# start fcitx5 daemon
+-if [ -x /usr/bin/fcitx5 ]; then
+-  /usr/bin/fcitx5 -d 2> /dev/null
+-fi

--- a/debian/patches/0003-fix-parallel-build-race-condition.patch
+++ b/debian/patches/0003-fix-parallel-build-race-condition.patch
@@ -1,0 +1,17 @@
+Description: Fix parallel build race between msgfmt and msgmerge
+ Ensure PO files have been updated before msgfmt generates the translated
+ desktop file, preventing concurrent reads while msgmerge writes a PO file.
+---
+diff --git a/Makefile b/Makefile
+index 472ea8d..914c7d9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -29,7 +29,7 @@ all: im-config im-config.desktop mo
+ im-config: im-config.in
+ 	sed -e "s/@@VERSION@@/$(VERSION)/" <$< >$@
+ 
+-im-config.desktop: im-config.desktop.in
++im-config.desktop: im-config.desktop.in po
+ 	msgfmt --desktop --template=$< -d po -o $@
+ 
+ po/locale/%/LC_MESSAGES/$(PROGRAM).mo: po/%.po

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,3 @@
+0001-add-desktop-file-NoDisplay-true.patch
+0002-do-not-start-fcitx5-daemon-by-im-config.patch
+0003-fix-parallel-build-race-condition.patch

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)


### PR DESCRIPTION
Add quilt patches for desktop visibility, fcitx5 launch, and parallel builds.

为桌面项隐藏、fcitx5 启动及并行构建添加 quilt 补丁。

Log: 重新添加 Deepin 补丁
Influence: 保持 Deepin 定制行为，并使用标准 quilt patch 管理。